### PR TITLE
Add support for Windows PowerShell

### DIFF
--- a/autoload/battery.vim
+++ b/autoload/battery.vim
@@ -89,6 +89,8 @@ function! s:get_available_backend() abort
     return 'pmset'
   elseif executable('ioreg')
     return 'ioreg'
+  elseif executable('powershell.exe')
+    return 'powershell'
   endif
   return 'dummy'
 endfunction

--- a/autoload/battery/backend/powershell.vim
+++ b/autoload/battery/backend/powershell.vim
@@ -1,0 +1,72 @@
+" Ref:  https://github.com/b4b4r07/dotfiles/blob/master/bin/battery
+let s:t_funcref = type(function('tr'))
+
+let s:powershell = {
+      \ 'job': 0,
+      \ 'data': [],
+      \ 'value': -1,
+      \ 'is_charging': -1,
+      \ 'callback': 0,
+      \}
+
+let s:callback_count = 0
+
+" mode0: charging indicator will be on when ac adopter is connected
+" mode1: charging indicator will be on only when battery is charging
+let s:mode = 1
+
+function! s:powershell.run_if_not_running()
+  if battery#job#is_alive(self.job)
+    return
+  endif
+  let options = {}
+  let options.err_cb = function('s:on_stderr', [self])
+  let self.job = job_start('powershell.exe -NoLogo -NonInteractive -NoExit -Command "function prompt() {''#''} Add-Type -Assembly System.Windows.Forms"', options)
+endfunction
+
+function! s:on_stderr(inst, channel, msg)
+  call a:inst.on_stderr(a:msg)
+endfunction
+function! s:powershell.on_stderr(msg)
+  if s:callback_count == s:mode
+    let self.is_charging = a:msg =~ 'Online'
+  elseif s:callback_count == s:mode
+    let self.is_charging = a:msg =~ 'Charging'
+  elseif s:callback_count == 2
+    let self.value = float2nr(100 * str2float(a:msg))
+  endif
+
+  if s:callback_count == 2
+    let s:callback_count = 0
+  else
+    let s:callback_count = s:callback_count + 1
+  endif
+
+endfunction
+
+
+function! s:powershell.update() abort
+  if s:callback_count != 0
+    return
+  endif
+  call s:powershell.run_if_not_running()
+  let l:channel = job_getchannel(self.job)
+  call ch_sendraw(l:channel, '[System.Windows.Forms.SystemInformation]::PowerStatus | %{echo $_.PowerLineStatus; echo $_.BatteryChargeStatus; echo $_.BatteryLifePercent} | %{[System.Console]::Error.WriteLine($_)}')
+  call ch_sendraw(l:channel, "\n")
+endfunction
+
+function! s:powershell.on_stdout(job, data, event) abort
+  " ignore all outputs of stdout because powershell cannot hide the prompt(PS>)
+endfunction
+
+function! s:powershell.on_exit(...) abort
+  " this function will never be called ?
+  if type(self.callback) == s:t_funcref
+    call self.callback()
+  endif
+endfunction
+
+
+function! battery#backend#powershell#define() abort
+  return s:powershell
+endfunction

--- a/autoload/battery/job.vim
+++ b/autoload/battery/job.vim
@@ -16,6 +16,9 @@ else
     if has_key(a:options, 'on_stdout')
       let options.out_cb = function('s:out_cb', [a:options])
     endif
+    if has_key(a:options, 'on_stderr')
+      let options.err_cb = function('s:err_cb', [a:options])
+    endif
     if has_key(a:options, 'on_exit')
       let options.exit_cb = function('s:exit_cb', [a:options])
     endif
@@ -34,6 +37,14 @@ else
     call call(
           \ a:instance.on_stdout,
           \ [a:channel, split(a:msg, '\r\?\n'), 'stdout'],
+          \ a:instance,
+          \)
+  endfunction
+
+  function! s:err_cb(instance, channel, msg) abort
+    call call(
+          \ a:instance.on_stderr,
+          \ [a:channel, split(a:msg, '\r\?\n'), 'stderr'],
           \ a:instance,
           \)
   endfunction


### PR DESCRIPTION
0495ad6 (this pull request) is better implementation than c14b627 (#1)

In c14b627, it runs a new powershell instance every check.
In 0495ad6, it runs a powershell instance and runs check command at first, and does not exit the instance. From the second check, it only runs check command on the instance. 

(Should I close #.1?)