### PR TITLE
Add full support for acpi

### DIFF
--- a/autoload/battery/backend/linux.vim
+++ b/autoload/battery/backend/linux.vim
@@ -1,7 +1,7 @@
 " Ref: https://github.com/lambdalisue/battery.vim/issues/7
-let s:Job = vital#battery#import('System.Job')
-let s:ac_online = get(glob('/sys/class/power_supply/AC*/online', 0, 1), 0, '')
-let s:bat_capacity = get(glob('/sys/class/power_supply/BAT*/capacity', 0, 1), 0, '')
+let s:bat_dirs = '/sys/class/power_supply/{CMD*,BAT*,battery}'
+let s:bat_status = get(glob(s:bat_dirs . '/status', 0, 1), 0, '')
+let s:bat_capacity = get(glob(s:bat_dirs . '/capacity', 0, 1), 0, '')
 
 function! s:read(path) abort
   let body = readfile(a:path)
@@ -9,7 +9,7 @@ function! s:read(path) abort
 endfunction
 
 function! s:linux_update() abort dict
-  let self.is_charging = s:read(s:ac_online) ==# '1'
+  let self.is_charging = s:read(s:bat_status) !=# 'Discharging'
   let self.value = s:read(s:bat_capacity) + 0
 endfunction
 
@@ -22,5 +22,5 @@ function! battery#backend#linux#define() abort
 endfunction
 
 function! battery#backend#linux#is_available() abort
-  return !empty(s:ac_online) && !empty(s:bat_capacity)
+  return !empty(s:bat_status) && !empty(s:bat_capacity)
 endfunction


### PR DESCRIPTION
Not all acpi client of linux use `/sys/class/power_supply/AC*/online` to show
if the battery is charging (at least my distribution).
`/sys/class/power_supply/BAT*/status` can did the same function.

after this change, now it can work in my linux.

![Screenshot from 2021-03-10 15-40-12](https://user-images.githubusercontent.com/32936898/110595546-15d2c700-81b9-11eb-8aad-01dc1be6a0ba.png)


And not only `/sys/class/power_supply/BAT*/status`, refer <https://github.com/romkatv/powerlevel10k/blob/master/internal/p10k.zsh#L1326>:

```sh
      local -a bats=( /sys/class/power_supply/(CMB*|BAT*|battery)/(FN) )
```

for example, my android use `/sys/class/power_supply/battery/status`
not `/sys/class/power_supply/BAT*/status`.

the backend can also work for android which work for root user (in android,
only root can have privilege to read `/sys`). for android work for non-root
user, the <https://github.com/lambdalisue/battery.vim/issues/9> is also a
valid substitution.

thanks for your review.