### PR TITLE
fixing termux backend for charging status and termux backend checker

### DIFF
--- a/autoload/battery.vim
+++ b/autoload/battery.vim
@@ -93,7 +93,7 @@ function! s:get_available_backend() abort
     return 'powershell'
   elseif battery#backend#linux#is_available()
     return 'linux'
-	elseif battery#backend#termux#is_available()
+  elseif battery#backend#termux#is_available()
     return 'termux'
   elseif battery#backend#freebsd#is_available()
     return 'freebsd'

--- a/autoload/battery.vim
+++ b/autoload/battery.vim
@@ -97,7 +97,6 @@ function! s:get_available_backend() abort
     return 'termux'
   elseif battery#backend#freebsd#is_available()
     return 'freebsd'
-
   endif
   return 'dummy'
 endfunction

--- a/autoload/battery.vim
+++ b/autoload/battery.vim
@@ -93,10 +93,11 @@ function! s:get_available_backend() abort
     return 'powershell'
   elseif battery#backend#linux#is_available()
     return 'linux'
+	elseif battery#backend#termux#is_available()
+    return 'termux'
   elseif battery#backend#freebsd#is_available()
     return 'freebsd'
-  elseif battery#backend#termux#is_available()
-    return 'termux'
+
   endif
   return 'dummy'
 endfunction

--- a/autoload/battery/backend/termux.vim
+++ b/autoload/battery/backend/termux.vim
@@ -19,7 +19,7 @@ endfunction
 
 function! s:on_exit(backend, buffer, exitval) abort
   let content = join(a:buffer, '')
-  let a:backend.is_charging = json_decode(content).status !=# 'DISCHARGING'
+  let a:backend.is_charging = json_decode(content).status !=# 'NOT_CHARGING' || 'DISCHARGING'
   let a:backend.value = json_decode(content).percentage + 0
 endfunction
 

--- a/autoload/battery/backend/termux.vim
+++ b/autoload/battery/backend/termux.vim
@@ -18,12 +18,10 @@ function! s:on_stdout(buffer, data) abort
 endfunction
 
 function! s:on_exit(backend, buffer, exitval) abort
-	let g:bat_status_list = ['NOT_CHARGING' , 'DISCHARGING']
-  let content = join(a:buffer, '')
-	if index(g:bat_status_list, json_decode(content).status) >= 0
-		let a:backend.is_charging = 0
-	endif
-  let a:backend.value = json_decode(content).percentage + 0
+  let obj = json_decode(join(a:buffer, ''))
+  let status = get(obj, 'status', '')
+  let a:backend.is_charging = !(status ==# 'NOT_CHARGING' || status ==# 'DISCHARGING')
+  let a:backend.value = get(obj, 'percentage', 0) + 0
 endfunction
 
 function! battery#backend#termux#define() abort

--- a/autoload/battery/backend/termux.vim
+++ b/autoload/battery/backend/termux.vim
@@ -18,8 +18,11 @@ function! s:on_stdout(buffer, data) abort
 endfunction
 
 function! s:on_exit(backend, buffer, exitval) abort
+	let g:bat_status_list = ['NOT_CHARGING' , 'DISCHARGING']
   let content = join(a:buffer, '')
-  let a:backend.is_charging = json_decode(content).status !=# 'NOT_CHARGING' || 'DISCHARGING'
+	if index(g:bat_status_list, json_decode(content).status) >= 0
+		let a:backend.is_charging = 0
+	endif
   let a:backend.value = json_decode(content).percentage + 0
 endfunction
 

--- a/autoload/battery/backend/termux.vim
+++ b/autoload/battery/backend/termux.vim
@@ -19,7 +19,7 @@ endfunction
 
 function! s:on_exit(backend, buffer, exitval) abort
   let content = join(a:buffer, '')
-  let a:backend.is_charging = json_decode(content).status !=# 'NOT_CHARGING'
+  let a:backend.is_charging = json_decode(content).status !=# 'DISCHARGING'
   let a:backend.value = json_decode(content).percentage + 0
 endfunction
 


### PR DESCRIPTION
It should fix battery status to show as always charging and it seems like placing termux backend checker (i don't know what it's called) below freebsd checker broke termux backend as there was exist sysctl, it fixed by just moving the checker upward

Ps. My English is bad