### PR TITLE
Add `battery#component_escaped()` and remove `%` escape from `battery#component()`

### DIFF
--- a/autoload/battery.vim
+++ b/autoload/battery.vim
@@ -64,6 +64,11 @@ function! battery#component() abort
   return format
 endfunction
 
+function! battery#component_escaped() abort
+  let component = battery#component()
+  return substitute(component, '%', '%%', 'g')
+endfunction
+
 function! s:update_callback() abort
   if g:battery#update_tabline
     let &tabline = &tabline

--- a/autoload/battery.vim
+++ b/autoload/battery.vim
@@ -114,7 +114,7 @@ call s:define('g:battery', {
       \ 'update_interval': 30000,
       \ 'update_tabline': 0,
       \ 'update_statusline': 0,
-      \ 'component_format': '%s %v%%%% %g',
+      \ 'component_format': '%s %v%% %g',
       \ 'symbol_charging': '♥',
       \ 'symbol_discharging': '♡',
       \ 'graph_indicators': [

--- a/doc/battery.txt
+++ b/doc/battery.txt
@@ -1,10 +1,5 @@
 *battery.txt*	A statusline/tabline component of Battery information
 
-Author:  Alisue <lambdalisue@hashnote.net>
-Support: Neovim 0.1.6 or above
-Support: Vim 8.0 or above
-License: MIT license
-
 =============================================================================
 CONTENTS					*battery-contents*
 

--- a/doc/battery.txt
+++ b/doc/battery.txt
@@ -116,6 +116,19 @@ battery#component()
 	Return a battery component for |statusline| or |tabline| which looks
 	like "♥ 40% ██░░░".
 	Users can customize the format by |g:battery#component_format|.
+>
+	set statusline=%{battery#component()}
+<
+	See |battery#component_escaped()| for "%!" expression.
+
+					*battery#component_escaped()*
+battery#component_escaped()
+	Return a "%" escaped battery component that is suite for "%!"
+	expression that like  "♥ 40%% ██░░░".
+>
+	set statusline=%!battery#component_escaped()
+<
+	See |battery#component()| for "%{}" expression.
 
 -----------------------------------------------------------------------------
 VARIABLES					*battery-variables*

--- a/doc/battery.txt
+++ b/doc/battery.txt
@@ -175,7 +175,7 @@ g:battery#component_format
 	%x		x
 	%%		%
 
-	Default is "%s %v%%%% %g"
+	Default is "%s %v%% %g"
 
 					*g:battery#graph_indicators*
 g:battery#graph_indicators


### PR DESCRIPTION
Close #22 