### PR TITLE
UPDATE: append available battery types

### DIFF
--- a/autoload/battery/backend/linux.vim
+++ b/autoload/battery/backend/linux.vim
@@ -1,5 +1,5 @@
 " Ref: https://github.com/lambdalisue/battery.vim/issues/7
-let s:bat_dirs = '/sys/class/power_supply/{CMD*,BAT*,battery}'
+let s:bat_dirs = '/sys/class/power_supply/{CMD*,BAT*,CMB*,battery}'
 let s:bat_status = get(glob(s:bat_dirs . '/status', 0, 1), 0, '')
 let s:bat_capacity = get(glob(s:bat_dirs . '/capacity', 0, 1), 0, '')
 


### PR DESCRIPTION
Hello,

I had a problem presenting the battery value on my laptop.

In order to solve the problem, I added my laptop battery type in the `linux.vim` file.

Since I experienced similar problem in an another project, I applied a same solution.
* dracula/tmux#244

Thank you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded battery type support in the Linux backend, allowing for a broader range of battery directories to be recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->